### PR TITLE
Include the `smode_laser_plugin` Rust library

### DIFF
--- a/smode_laser_plugin/.gitignore
+++ b/smode_laser_plugin/.gitignore
@@ -1,0 +1,4 @@
+target/
+**/*.rs.bk
+Cargo.lock
+.DS_Store

--- a/smode_laser_plugin/Cargo.toml
+++ b/smode_laser_plugin/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "smode_laser_plugin"
+version = "0.1.0"
+authors = [
+    "mitchmindtree <mitchell.nordine@gmail.com>",
+    "JoshuaBatty <joshpbatty@gmail.com>",
+]
+description = "A small library extending `nannou_laser` for SMODE"
+keywords = ["laser", "dac", "stream", "frame", "smode"]
+repository = "https://github.com/mindbuffer/smode_laser_plugin.git"
+homepage = "https://github.com/mindbuffer/smode_laser_plugin"
+edition = "2018"
+
+[lib]
+name = "smode_laser_plugin"
+crate-type = ["rlib", "staticlib", "cdylib"]
+
+[dependencies]
+nannou_laser = { git = "https://github.com/nannou-org/nannou", branch = "master", features = ["ffi"] }

--- a/smode_laser_plugin/README.md
+++ b/smode_laser_plugin/README.md
@@ -1,0 +1,64 @@
+# smode_laser_plugin (Rust library)
+
+A small library extending the `nannou_laser` library with some SMODE-specific
+requirements. We use this library within our C++ SMODE plugin by compiling it to
+a static library, generating a C header using `cbindgen` and linking to the
+static library using the traditional SMODE approach. These steps are explained
+in more detail below.
+
+## Building the library
+
+We can build this library from scratch by following these steps:
+
+1. Install Rust. Follow the instructions [here][1]. If you are new to Rust, you
+   can learn more about the language [here][2], however this is not necessary
+   for the following steps.
+
+2. Clone the repository:
+   ```
+   git clone https://github.com/MindBuffer/smode_laser_plugin.git
+   ```
+
+3. Change to this library's directory:
+   ```
+   cd smode_laser_plugin/smode_laser_plugin
+   ```
+
+4. Build the library with optimisations enabled:
+   ```
+   cargo build --release
+   ```
+   Note that the first `cargo build` might take a while as cargo fetches the
+   registry, the necessary dependencies and builds the library from scratch.
+
+If all went well, we should now have our static library at
+`target/release/libsmode_laser_plugin.<ext>` where `<ext>` is the static library
+extension for your platform.
+
+## Generating the C header
+
+This library along with the `nannou_laser` and `ether-dream` dependencies expose
+a C-ABI compatible API using Rust's foreign function interface. In order to call
+into these functions from C or C++ code, we require a header file with a set of
+extern function declarations that exactly match those exposed by our Rust code.
+Rather than writing this header manually, we can generate it using a tool called
+[cbindgen][3]. This tool creates C/C++11 headers for Rust libraries which expose
+a public C API. Let's generate our header:
+
+1. Install cbindgen:
+   ```
+   cargo install cbindgen
+   ```
+
+2. Generate the bindings:
+   ```
+   cbindgen --crate smode_laser_plugin --output smode_laser_plugin.h
+   ```
+
+We should now have a `smode_laser_plugin.h` file containing all the necessary
+extern declarations for calling into our static library! We are now ready to
+include our static library and header in our plugin.
+
+[1]: https://www.rust-lang.org/tools/install
+[2]: https://www.rust-lang.org/learn
+[3]: https://github.com/eqrion/cbindgen

--- a/smode_laser_plugin/cbindgen.toml
+++ b/smode_laser_plugin/cbindgen.toml
@@ -1,0 +1,4 @@
+[parse]
+parse_deps = true
+include = ["nannou_laser", "ether-dream"]
+extra_bindings = ["nannou_laser", "ether-dream"]

--- a/smode_laser_plugin/smode_laser_plugin.h
+++ b/smode_laser_plugin/smode_laser_plugin.h
@@ -1,0 +1,4 @@
+#include <cstdarg>
+#include <cstdint>
+#include <cstdlib>
+#include <new>

--- a/smode_laser_plugin/src/lib.rs
+++ b/smode_laser_plugin/src/lib.rs
@@ -1,0 +1,13 @@
+//! This library acts as a small extension to the `nannou_laser` library, providing a small set of
+//! SMODE-specific items as they are required during development of the plugin.
+//!
+//! We use this library within our C++ SMODE plugin by compiling it to a static library, generating
+//! a C header using `cbindgen` and linking to the static library using the traditional SMODE
+//! approach. Please see the `README.md` for a detailed guide.
+//!
+//! This library re-exports the `nannou_laser` library in its entirety.
+
+#[doc(inline)]
+pub use nannou_laser::*;
+
+// TODO: Add SMODE specific items here.


### PR DESCRIPTION
This adds a small library aimed at extending `nannou_laser` for the
needs of the SMODE plugin. Also includes a detailed README on how to
build a static library and generate a header that we can call into from
C++. See the README for more details!