### PR TITLE
Abstract `LaserDevice`. Add `NannouLaserDevice`.

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -8,9 +8,10 @@ find_package(SmodeSDK REQUIRED)
 SET (LASER_PLUGIN_SOURCES
   LaserPoint.sglsl
   LaserInputGeometryShader.sglsl
-  LaserDeviceIdentifier.h
+  NannouLaserDeviceIdentifier.h
+  NannouLaserDevice.h
+  NannouLaserDeviceFactory.h
   LaserDevice.h
-  LaserDeviceFactory.h
   LaserDeviceSelector.h
   LaserInputGeometry.h
   LaserGeometryRenderer.h

--- a/plugin/LaserDevice.h
+++ b/plugin/LaserDevice.h
@@ -16,7 +16,7 @@ class LaserDevice : public ControlDevice
 public:
   LaserDevice(const DeviceIdentifier& identifier)
     : ControlDevice(identifier) {}
-  LaserDevice(); // default constructible for proxy
+  LaserDevice() {} // default constructible for proxy
 
   struct Point
   {
@@ -35,8 +35,9 @@ public:
   // and cleared once per `update`.
   virtual void addLineSequence(const std::vector<Point>& new_points) = 0;
 
-  OIL_OBJECT(NannouLaserDevice);
-}
+  OIL_ABSTRACT_OBJECT(LaserDevice);
+};
+
 }; /* namespace smode */
 
 #endif // !SMODE_LASER_DEVICE_H_

--- a/plugin/LaserDevice.h
+++ b/plugin/LaserDevice.h
@@ -8,212 +8,15 @@
 # define SMODE_LASER_DEVICE_H_
 
 #include "LaserLibrary.h"
-#include "../smode_laser/smode_laser.h"
 
 namespace smode
 {
-struct CallbackData {
-  laser::FrameReceiver frame_rx;
-  laser::FrameMsg msg;
-  Device* laser_device;
-};
-
-void frameRenderCallback(void* data, laser::Frame* frame) {
-  CallbackData* cb_data = (CallbackData*)data;
-  // Ensure the device status is in the success state.
-  if (cb_data->laser_device->getStatus().getState() != SuccessState::success) {
-      SuccessStatus status = SuccessStatus();
-      status.setSuccess();
-      cb_data->laser_device->setStatusFromOtherThread(status);
-  }
-  // Update our current frame data.
-  laser::FrameMsg msg = cb_data->msg;
-  if (laser::recv_frame_msg(&cb_data->frame_rx, &cb_data->msg)) {
-    laser::frame_msg_drop(msg);
-    msg = cb_data->msg;
-  }
-  // Write the data to the frame.
-  laser::extend_frame_with_msg(frame, &cb_data->msg);
-}
-
-void processRawCallback(void* data, laser::Buffer* buffer) {
-  // Nothing to be done.
-}
-
-String streamErrorToString(const laser::StreamError* err) {
-    laser::RawString rs = laser::stream_error_message(err);
-    String message = String(laser::raw_string_ref(&rs));
-    laser::raw_string_drop(rs);
-    return message;
-}
-
-void streamErrorCallback(void* data, const laser::StreamError* err, laser::StreamErrorAction* action) {
-  // Update the status if the message would have changed.
-  CallbackData* cb_data = (CallbackData*)data;
-  SuccessStatus status = cb_data->laser_device->getStatus();
-  String msg = streamErrorToString(err);
-  if (status.getMessage() != msg) {
-      status.setError(msg);
-      cb_data->laser_device->setStatusFromOtherThread(status);
-  }
-
-  // Handle the error.
-  switch (laser::stream_error_kind(err)) {
-    // If communication dropped out, re-attempt to connect to the TCP stream.
-    case laser::StreamErrorKind::EtherDreamFailedToPrepareStream:
-    case laser::StreamErrorKind::EtherDreamFailedToBeginStream:
-    case laser::StreamErrorKind::EtherDreamFailedToSubmitData:
-    case laser::StreamErrorKind::EtherDreamFailedToSubmitPointRate:
-      laser::stream_error_action_set_reattempt_connect(action);
-      break;
-
-    // Attempt re-connection 5 times before attempting to re-detect the DAC.
-    case laser::StreamErrorKind::EtherDreamFailedToConnectStream:
-      if (laser::stream_error_attempts(err) % 5 != 0) {
-        laser::stream_error_action_set_reattempt_connect(action);
-      } else {
-        float timeout_secs = 1.1;
-        laser::stream_error_action_set_redetect_dacs(action, timeout_secs);
-      }
-      break;
-
-    // If we failed to detect the DAC, try again.
-    // Note: If an ether dream DAC is broadcasting, it does so once per second.
-    case laser::StreamErrorKind::EtherDreamFailedToDetectDacs: {
-      float timeout_secs = 1.1;
-      laser::stream_error_action_set_redetect_dacs(action, timeout_secs);
-      break;
-    }
-
-    // The default action is to close the thread.
-    default:
-      break;
-  }
-}
-
 class LaserDevice : public ControlDevice
 {
 public:
-  LaserDevice(const DeviceIdentifier& identifier, laser::DetectedDac _dac)
-    : ControlDevice(identifier), dacPointsPerSecond(10000), latencyPoints(166), targetFps(60), blankDelayPoints(10), distancePerPoint(0.1), anglePerPoint(0.6), dac(_dac),
-    callback_data(std::make_shared<CallbackData>())
-  {
-    dacPointsPerSecond.setParent(this);
-    latencyPoints.setParent(this);
-    targetFps.setParent(this);
-    distancePerPoint.setParent(this);
-    blankDelayPoints.setParent(this);
-    anglePerPoint.setParent(this);
-  }
-  LaserDevice() {}
-
-  // Object
-  bool hasVariableConstraints() const override
-    {return true;}
-
-  void variableChangedCallback(Object* variable, Object* changedObject) override
-  {      
-    if (isRenderingServiceCurrent() && isInitialized()) {
-      if (variable == &dacPointsPerSecond) {
-        uint32_t dpps = juce::jlimit((uint32_t)1000, (uint32_t)dac.kind.ether_dream.broadcast.max_point_rate, (uint32_t)dacPointsPerSecond);
-        laser::frame_stream_set_point_hz(&frame_stream, dpps);
-      }
-      else if (variable == &latencyPoints) {
-        uint32_t lp = juce::jlimit((uint32_t)10, (uint32_t)dac.kind.ether_dream.broadcast.buffer_capacity, (uint32_t)latencyPoints);
-        laser::frame_stream_set_latency_points(&frame_stream, lp);
-      }
-      else if (variable == &targetFps) {
-        laser::frame_stream_set_frame_hz(&frame_stream, (uint32_t)targetFps);
-      }
-      else if (variable == &distancePerPoint) {
-        laser::frame_stream_set_distance_per_point(&frame_stream, (uint32_t)distancePerPoint);
-      }
-      else if (variable == &blankDelayPoints) {
-        laser::frame_stream_set_blank_delay_points(&frame_stream, (uint32_t)blankDelayPoints);
-      }
-      else if (variable == &anglePerPoint) {
-        laser::frame_stream_set_radians_per_point(&frame_stream, (float)anglePerPoint);
-      }
-    }
-   
-   
-    if (isApplyingVariableConstraints() && isRenderingServiceCurrent()) {
-      if (variable == &dacPointsPerSecond) {
-        VariableConstraintsScope _(*this);
-        uint32_t runtimeMax = dac.kind.ether_dream.broadcast.max_point_rate;
-        if ((uint32_t)dacPointsPerSecond > runtimeMax) 
-          dacPointsPerSecond.set(runtimeMax);
-      }
-      else if (variable == &latencyPoints) {
-        VariableConstraintsScope _(*this);
-        uint32_t runtimeMax = dac.kind.ether_dream.broadcast.buffer_capacity;
-        if ((uint32_t)latencyPoints > runtimeMax)
-          latencyPoints.set(runtimeMax);
-      }
-    }
-    
-    BaseClass::variableChangedCallback(variable, changedObject);
-  }
-  
-  bool initializeDevice() override {
-    BaseClass::initializeDevice();
-
-    // Prepare the callback data and frame msg queue.
-    laser::frame_msg_new(&callback_data->msg);
-    laser::frame_queue_new(&frame_tx, &callback_data->frame_rx);
-    callback_data->laser_device = this;
-
-    // Initialise the stream with default configuration.
-    laser::FrameStreamConfig config = {};
-    laser::frame_stream_config_default(&config);
-    config.stream_conf.tcp_timeout_secs = 1.2;
-    config.stream_conf.detected_dac = &dac;
-    config.interpolation_conf.blank_delay_points = (uint32_t)blankDelayPoints;
-    config.interpolation_conf.distance_per_point = (uint32_t)distancePerPoint;
-    config.interpolation_conf.radians_per_point = (float)anglePerPoint;
-    config.frame_hz = (uint32_t)targetFps;
-    config.stream_conf.latency_points = (uint32_t)latencyPoints;
-    config.stream_conf.point_hz = (uint32_t)dacPointsPerSecond;
-
-    // Data to be shared with the frame render callback.
-    // For now, just share the frame receiver.
-    CallbackData* cb_data_ptr = callback_data.get();
-    void* callback_data = cb_data_ptr;
-
-    // Spawn the stream.
-    laser::Result res = laser::new_frame_stream(
-      laser_api,
-      &frame_stream,
-      &config,
-      callback_data,
-      frameRenderCallback,
-      processRawCallback,
-      streamErrorCallback
-    );
-
-    if (res != laser::Result::Success) {
-      const char* err = laser::api_last_error(laser_api);
-      String failureReason = "Failed to spawn laser frame stream: " + String(err);
-      DBG(failureReason);
-      return false;
-    }
-
-    return true;
-  }
-
-  void deinitializeDevice() override {
-    // Clean up the frame resources and ensure the thread is joined.
-    laser::frame_stream_drop(frame_stream);
-    // Now that the laser thread is stopped, we can clean up our channel and callback data.
-    laser::frame_sender_drop(frame_tx);
-    laser::frame_receiver_drop(callback_data->frame_rx);
-    laser::frame_msg_drop(callback_data->msg);
-    BaseClass::deinitializeDevice();
-  }
-
-  virtual void update(const FrameInformation& frame) override {
-      updateFrame();
-  }
+  LaserDevice(const DeviceIdentifier& identifier)
+    : ControlDevice(identifier) {}
+  LaserDevice(); // default constructible for proxy
 
   struct Point
   {
@@ -222,66 +25,18 @@ public:
     uint32_t weight; // 0 for smooth line segments, > 0 for accenting individual points
   };
 
-  // Concatenates the given points onto the points to be presented this frame.
-  // This method will blank from the last of the existing frame points to the
-  // first of the given new points.
-  void concatFramePoints(const std::vector<Point>& new_points) {
-      // Blank from the last renderer's last point to the first new point.
-      if (!frame_points.empty() && !new_points.empty()) {
-          Point a = frame_points.back();
-          Point b = new_points.front();
-          a.color = glm::vec3(0.f);
-          b.color = glm::vec3(0.f);
-          frame_points.push_back(a);
-          frame_points.push_back(b);
-      }
-      frame_points.insert(frame_points.end(), new_points.begin(), new_points.end());
-  }
+  // Concatenate the given points representing a line sequence onto the points
+  // to be presented for this frame.
+  //
+  // This method will be called once for each `LaserGeometryRenderer` targeting
+  // the `LaserDevice` per `update`. It is the responsibility of the
+  // implementor to ensure that a blank line is inserted between each added
+  // line sequence. The accumulated points should be flushed to the LASER DAC
+  // and cleared once per `update`.
+  virtual void addLineSequence(const std::vector<Point>& new_points) = 0;
 
-  // Send the current `frame_points` as a `FrameMsg` to the DAC callback.
-  void updateFrame() {
-    // We always want to send a msg, even if there were no points.
-    // This is because the render callback always emits the last frame received.
-    laser::FrameMsg msg;
-    laser::frame_msg_new(&msg);
-    // Write points if we're not muted, we're not in an error state and we actually have some.
-    if (!frame_points.empty() && !mute && !getStatus().isError()) {
-      // Layout *must* match or we will get very strange behaviour.
-      jassert(sizeof(Point) == sizeof(laser::Point));
-      const laser::Point* points = reinterpret_cast<const laser::Point*>(&frame_points[0]);
-      laser::SequenceType ty = laser::SequenceType::Lines;
-      laser::frame_msg_add_sequence(&msg, ty, points, frame_points.size());
-    }
-    laser::send_frame_msg(&frame_tx, msg);
-    // Clear the frame points, ready to collect from the renderers before next update.
-    frame_points.clear();
-  }
-
-  // A pointer to the laser API instance.
-  // Is valid between `initializeFactory` and `deinitializeFactory`.
-  laser::Api* laser_api;
-  // The detected DAC associated with this Device instance.
-  laser::DetectedDac dac;
-  laser::FrameStream frame_stream;
-  laser::FrameSender frame_tx;
-  // Shared with the laser callback.
-  std::shared_ptr<CallbackData> callback_data;
-  // The buffer used for collecting points from each of the geometry renderers.
-  std::vector<Point> frame_points;
-
-  OIL_OBJECT(LaserDevice);
-
-private:
-  typedef ControlDevice BaseClass;
-
-  PositiveInteger dacPointsPerSecond;
-  PositiveInteger latencyPoints;
-  PositiveInteger targetFps;
-  Percentage distancePerPoint;
-  PositiveInteger blankDelayPoints;
-  PositiveAngle anglePerPoint; // This is actually in radians but displayed to the user in degrees
-};
-
+  OIL_OBJECT(NannouLaserDevice);
+}
 }; /* namespace smode */
 
 #endif // !SMODE_LASER_DEVICE_H_

--- a/plugin/LaserDeviceSelector.h
+++ b/plugin/LaserDeviceSelector.h
@@ -23,7 +23,6 @@ public:
 
   OIL_ABSTRACT_OBJECT(LaserDeviceSelector);
 };
-
 }; /* namespace smode */
 
 #endif // !SMODE_LASER_DEVICE_SELECTOR_H_

--- a/plugin/LaserGeometryRenderer.h
+++ b/plugin/LaserGeometryRenderer.h
@@ -43,7 +43,7 @@ public:
 
     points.clear();
     computeFinalPoints(downloadedPoints, points);
-    laserDevice->concatFramePoints(points);
+    laserDevice->addLineSequence(points);
   }
 
   // Element

--- a/plugin/LaserLibrary.xml
+++ b/plugin/LaserLibrary.xml
@@ -5,13 +5,15 @@
   <description language="us-en">Smode Laser plugin.</description>
   <include fromApi="true" file="SmodeSDK/SmodeSDK.h" public="true"/>
 
-  <class name="LaserDeviceFactory" base="DeviceFactory">
-    <attribute name="deviceBaseClass">ControlDevice</attribute>
-    <attribute name="deviceClass">LaserDevice</attribute>
+  <class name="NannouLaserDeviceFactory" base="DeviceFactory">
+    <attribute name="deviceBaseClass">LaserDevice</attribute>
+    <attribute name="deviceClass">NannouLaserDevice</attribute>
   </class>
-  <class name="LaserDeviceIdentifier" base="StringDeviceIdentifier"/>
+  <class name="NannouLaserDeviceIdentifier" base="StringDeviceIdentifier"/>
   
-  <class name="LaserDevice" base="ControlDevice">
+  <class name="LaserDevice" base="ControlDevice" abstract="true"/>
+
+  <class name="NannouLaserDevice" base="LaserDevice">
     <variable class="PositiveInteger" name="dacPointsPerSecond" default="10000">
       <attribute name ="friendlyName">"DAC Points Per Second"</attribute>
       <attribute name ="minimum">1000</attribute>

--- a/plugin/NannouLaserDevice.h
+++ b/plugin/NannouLaserDevice.h
@@ -16,7 +16,7 @@ class NannouLaserDevice : public LaserDevice
 {
 public:
   NannouLaserDevice(const DeviceIdentifier& identifier, laser::Api* _api, laser::DetectedDac _dac)
-    : LaserDevice(identifier), dacPointsPerSecond(10000), latencyPoints(166), targetFps(60), blankDelayPoints(10), distancePerPoint(0.1), anglePerPoint(0.6), api(_api), dac(_dac), callback_data(std::make_shared<CallbackData>())
+    : LaserDevice(identifier), dacPointsPerSecond(10000), latencyPoints(166), targetFps(60), blankDelayPoints(10), distancePerPoint(0.1), anglePerPoint(0.6), laser_api(_api), dac(_dac), callback_data(std::make_shared<CallbackData>())
   {
     dacPointsPerSecond.setParent(this);
     latencyPoints.setParent(this);
@@ -257,7 +257,7 @@ private:
   // `streamErrorCallback`. The current `streamErrorCallback` implementation
   // will continuously attempt to re-connect to the TCP stream or re-detect the
   // DAC in the case that a timeout occurs.
-  static const float TCP_TIMEOUT_SECS = 1.2;
+  static const uint32_t TCP_TIMEOUT_SECS = 2;
   // The number of times to attempt re-connecting to the TCP stream in the case
   // that it drops out. Once this number is exceeded, the `streamErrorCallback`
   // implementation will then attempt to re-detect the DAC.
@@ -288,7 +288,7 @@ private:
   PositiveAngle anglePerPoint; // This is actually in radians but displayed to the user in degrees
 
   typedef LaserDevice BaseClass;
-}
+};
 }; // namespace smode
 
 #endif // !SMODE_NANNOU_LASER_DEVICE_H_

--- a/plugin/NannouLaserDevice.h
+++ b/plugin/NannouLaserDevice.h
@@ -1,0 +1,294 @@
+/* -------------------------------------- . ---------------------------------- .
+| Filename : NannouLaserDevice.h          |                                    |
+| Author   : MindBuffer                   |                                    |
+| Started  : 17/04/2020 13:05             |                                    |
+` --------------------------------------- . --------------------------------- */
+
+#ifndef SMODE_NANNOU_LASER_DEVICE_H_
+# define SMODE_NANNOU_LASER_DEVICE_H_
+
+#include "LaserDevice.h"
+#include "../smode_laser/smode_laser.h"
+
+namespace smode
+{
+class NannouLaserDevice : public LaserDevice
+{
+public:
+  NannouLaserDevice(const DeviceIdentifier& identifier, laser::Api* _api, laser::DetectedDac _dac)
+    : LaserDevice(identifier), dacPointsPerSecond(10000), latencyPoints(166), targetFps(60), blankDelayPoints(10), distancePerPoint(0.1), anglePerPoint(0.6), api(_api), dac(_dac), callback_data(std::make_shared<CallbackData>())
+  {
+    dacPointsPerSecond.setParent(this);
+    latencyPoints.setParent(this);
+    targetFps.setParent(this);
+    distancePerPoint.setParent(this);
+    blankDelayPoints.setParent(this);
+    anglePerPoint.setParent(this);
+  }
+  NannouLaserDevice() {}
+
+  bool hasVariableConstraints() const override
+    {return true;}
+
+  void variableChangedCallback(Object* variable, Object* changedObject) override
+  {      
+    if (!isRenderingServiceCurrent())
+      return;
+
+    if (isInitialized()) {
+      if (variable == &dacPointsPerSecond) {
+        uint32_t dpps = juce::jlimit((uint32_t)1000, (uint32_t)dac.kind.ether_dream.broadcast.max_point_rate, (uint32_t)dacPointsPerSecond);
+        laser::frame_stream_set_point_hz(&frame_stream, dpps);
+      }
+      else if (variable == &latencyPoints) {
+        uint32_t lp = juce::jlimit((uint32_t)10, (uint32_t)dac.kind.ether_dream.broadcast.buffer_capacity, (uint32_t)latencyPoints);
+        laser::frame_stream_set_latency_points(&frame_stream, lp);
+      }
+      else if (variable == &targetFps) {
+        laser::frame_stream_set_frame_hz(&frame_stream, (uint32_t)targetFps);
+      }
+      else if (variable == &distancePerPoint) {
+        laser::frame_stream_set_distance_per_point(&frame_stream, (uint32_t)distancePerPoint);
+      }
+      else if (variable == &blankDelayPoints) {
+        laser::frame_stream_set_blank_delay_points(&frame_stream, (uint32_t)blankDelayPoints);
+      }
+      else if (variable == &anglePerPoint) {
+        laser::frame_stream_set_radians_per_point(&frame_stream, (float)anglePerPoint);
+      }
+    }
+
+    if (isApplyingVariableConstraints()) {
+      if (variable == &dacPointsPerSecond) {
+        VariableConstraintsScope _(*this);
+        uint32_t runtimeMax = dac.kind.ether_dream.broadcast.max_point_rate;
+        if ((uint32_t)dacPointsPerSecond > runtimeMax)
+          dacPointsPerSecond.set(runtimeMax);
+      }
+      else if (variable == &latencyPoints) {
+        VariableConstraintsScope _(*this);
+        uint32_t runtimeMax = dac.kind.ether_dream.broadcast.buffer_capacity;
+        if ((uint32_t)latencyPoints > runtimeMax)
+          latencyPoints.set(runtimeMax);
+      }
+    }
+
+    BaseClass::variableChangedCallback(variable, changedObject);
+  }
+
+  bool initializeDevice() override {
+    BaseClass::initializeDevice();
+
+    // Prepare the callback data and frame msg queue.
+    laser::frame_msg_new(&callback_data->msg);
+    laser::frame_queue_new(&frame_tx, &callback_data->frame_rx);
+    callback_data->laser_device = this;
+
+    // Initialise the stream with default configuration.
+    laser::FrameStreamConfig config = {};
+    laser::frame_stream_config_default(&config);
+    config.stream_conf.tcp_timeout_secs = TCP_TIMEOUT_SECS;
+    config.stream_conf.detected_dac = &dac;
+    config.interpolation_conf.blank_delay_points = (uint32_t)blankDelayPoints;
+    config.interpolation_conf.distance_per_point = (uint32_t)distancePerPoint;
+    config.interpolation_conf.radians_per_point = (float)anglePerPoint;
+    config.frame_hz = (uint32_t)targetFps;
+    config.stream_conf.latency_points = (uint32_t)latencyPoints;
+    config.stream_conf.point_hz = (uint32_t)dacPointsPerSecond;
+
+    // Data to be shared with the frame render callback.
+    // For now, just share the frame receiver.
+    CallbackData* cb_data_ptr = callback_data.get();
+    void* callback_data = cb_data_ptr;
+
+    // Spawn the stream.
+    laser::Result res = laser::new_frame_stream(
+      laser_api,
+      &frame_stream,
+      &config,
+      callback_data,
+      NannouLaserDevice::frameRenderCallback,
+      NannouLaserDevice::processRawCallback,
+      NannouLaserDevice::streamErrorCallback
+    );
+
+    if (res != laser::Result::Success) {
+      const char* err = laser::api_last_error(laser_api);
+      String failureReason = "Failed to spawn laser frame stream: " + String(err);
+      DBG(failureReason);
+      return false;
+    }
+
+    return true;
+  }
+
+  void deinitializeDevice() override {
+    // Clean up the frame resources and ensure the thread is joined.
+    laser::frame_stream_drop(frame_stream);
+    // Now that the laser thread is stopped, we can clean up our channel and callback data.
+    laser::frame_sender_drop(frame_tx);
+    laser::frame_receiver_drop(callback_data->frame_rx);
+    laser::frame_msg_drop(callback_data->msg);
+    BaseClass::deinitializeDevice();
+  }
+
+  void update(const FrameInformation& frame) override {
+      updateFrame();
+  }
+
+  void addLineSequence(const std::vector<Point>& new_points) override {
+    if (!frame_points.empty() && !new_points.empty()) {
+        Point a = frame_points.back();
+        Point b = new_points.front();
+        a.color = glm::vec3(0.f);
+        b.color = glm::vec3(0.f);
+        frame_points.push_back(a);
+        frame_points.push_back(b);
+    }
+    frame_points.insert(frame_points.end(), new_points.begin(), new_points.end());
+  }
+
+  // Send the current `frame_points` as a `FrameMsg` to the DAC callback.
+  void updateFrame() {
+    // We always want to send a msg, even if there were no points.
+    // This is because the render callback always emits the last frame received.
+    laser::FrameMsg msg;
+    laser::frame_msg_new(&msg);
+    // Write points if we're not muted, we're not in an error state and we actually have some.
+    if (!frame_points.empty() && !mute && !getStatus().isError()) {
+      // Layout *must* match or we will get very strange behaviour.
+      jassert(sizeof(Point) == sizeof(laser::Point));
+      const laser::Point* points = reinterpret_cast<const laser::Point*>(&frame_points[0]);
+      laser::SequenceType ty = laser::SequenceType::Lines;
+      laser::frame_msg_add_sequence(&msg, ty, points, frame_points.size());
+    }
+    laser::send_frame_msg(&frame_tx, msg);
+    // Clear the frame points, ready to collect from the renderers before next update.
+    frame_points.clear();
+  }
+
+  OIL_OBJECT(NannouLaserDevice);
+
+private:
+  // Data shared between the stream thread and the GUI rendering thread.
+  struct CallbackData {
+    laser::FrameReceiver frame_rx;
+    laser::FrameMsg msg;
+    Device* laser_device;
+  };
+
+  // Called by the DAC stream thread when ready for a new frame of points.
+  static void frameRenderCallback(void* data, laser::Frame* frame) {
+    CallbackData* cb_data = (CallbackData*)data;
+    // Ensure the device status is in the success state.
+    if (cb_data->laser_device->getStatus().getState() != SuccessState::success) {
+        SuccessStatus status = SuccessStatus();
+        status.setSuccess();
+        cb_data->laser_device->setStatusFromOtherThread(status);
+    }
+    // Update our current frame data.
+    laser::FrameMsg msg = cb_data->msg;
+    if (laser::recv_frame_msg(&cb_data->frame_rx, &cb_data->msg)) {
+      laser::frame_msg_drop(msg);
+      msg = cb_data->msg;
+    }
+    // Write the data to the frame.
+    laser::extend_frame_with_msg(frame, &cb_data->msg);
+  }
+
+  // Called by the DAC stream thread after interpolation and optimisations have
+  // been applied, right before sending the points to the DAC. This is normally
+  // used if some post-processing must be applied on the points, but normally
+  // this can be done prior to submitting points to the frame render callback.
+  static void processRawCallback(void* data, laser::Buffer* buffer) {
+    // Nothing to be done.
+  }
+
+  static String streamErrorToString(const laser::StreamError* err) {
+      laser::RawString rs = laser::stream_error_message(err);
+      String message = String(laser::raw_string_ref(&rs));
+      laser::raw_string_drop(rs);
+      return message;
+  }
+
+  // Called by the DAC stream thread when some error occurs.
+  static void streamErrorCallback(void* data, const laser::StreamError* err, laser::StreamErrorAction* action) {
+    // Update the status if the message would have changed.
+    CallbackData* cb_data = (CallbackData*)data;
+    SuccessStatus status = cb_data->laser_device->getStatus();
+    String msg = NannouLaserDevice::streamErrorToString(err);
+    if (status.getMessage() != msg) {
+        status.setError(msg);
+        cb_data->laser_device->setStatusFromOtherThread(status);
+    }
+    // Handle the error.
+    switch (laser::stream_error_kind(err)) {
+      // If communication dropped out, re-attempt to connect to the TCP stream.
+      case laser::StreamErrorKind::EtherDreamFailedToPrepareStream:
+      case laser::StreamErrorKind::EtherDreamFailedToBeginStream:
+      case laser::StreamErrorKind::EtherDreamFailedToSubmitData:
+      case laser::StreamErrorKind::EtherDreamFailedToSubmitPointRate:
+        laser::stream_error_action_set_reattempt_connect(action);
+        break;
+      // Attempt re-connection 5 times before attempting to re-detect the DAC.
+      case laser::StreamErrorKind::EtherDreamFailedToConnectStream:
+        if (laser::stream_error_attempts(err) % TCP_RECONNECT_ATTEMPTS != 0) {
+          laser::stream_error_action_set_reattempt_connect(action);
+        } else {
+          float timeout_secs = TCP_TIMEOUT_SECS;
+          laser::stream_error_action_set_redetect_dacs(action, timeout_secs);
+        }
+        break;
+      // If we failed to detect the DAC, try again.
+      // Note: If an ether dream DAC is broadcasting, it does so once per second.
+      case laser::StreamErrorKind::EtherDreamFailedToDetectDacs: {
+        float timeout_secs = TCP_TIMEOUT_SECS;
+        laser::stream_error_action_set_redetect_dacs(action, timeout_secs);
+        break;
+      }
+      // The default action is to close the thread.
+      default:
+        break;
+    }
+  }
+
+  // The TCP timeout describes how long the stream should wait to connect, read
+  // or write to or from the TCP stream before emitting an error via the
+  // `streamErrorCallback`. The current `streamErrorCallback` implementation
+  // will continuously attempt to re-connect to the TCP stream or re-detect the
+  // DAC in the case that a timeout occurs.
+  static const float TCP_TIMEOUT_SECS = 1.2;
+  // The number of times to attempt re-connecting to the TCP stream in the case
+  // that it drops out. Once this number is exceeded, the `streamErrorCallback`
+  // implementation will then attempt to re-detect the DAC.
+  static const uint32_t TCP_RECONNECT_ATTEMPTS = 5;
+
+  // A pointer to the laser API instance.
+  // Is valid between `initializeFactory` and `deinitializeFactory`.
+  laser::Api* laser_api;
+  // The detected DAC associated with this Device instance.
+  laser::DetectedDac dac;
+
+  // A handle to the DAC stream thread.
+  // Valid between `initializeDevice` and `deinitializeDevice`.
+  laser::FrameStream frame_stream;
+  // The sending half of the thread-safe, bounded, non-blocking queue for
+  // sending `FrameMsg`s.
+  laser::FrameSender frame_tx;
+  // Shared with the laser callback.
+  std::shared_ptr<CallbackData> callback_data;
+  // The buffer used for collecting points from each of the geometry renderers.
+  std::vector<Point> frame_points;
+
+  PositiveInteger dacPointsPerSecond;
+  PositiveInteger latencyPoints;
+  PositiveInteger targetFps;
+  Percentage distancePerPoint;
+  PositiveInteger blankDelayPoints;
+  PositiveAngle anglePerPoint; // This is actually in radians but displayed to the user in degrees
+
+  typedef LaserDevice BaseClass;
+}
+}; // namespace smode
+
+#endif // !SMODE_NANNOU_LASER_DEVICE_H_

--- a/plugin/NannouLaserDeviceFactory.h
+++ b/plugin/NannouLaserDeviceFactory.h
@@ -1,15 +1,15 @@
 /* -------------------------------------- . ---------------------------------- .
-| Filename : LaserDeviceFactory.h         |                                    |
+| Filename : NannouLaserDeviceFactory.h   |                                    |
 | Author   : MindBuffer                   |                                    |
 | Started  : 05/04/2020 07:16             |                                    |
 ` --------------------------------------- . --------------------------------- */
 
-#ifndef SMODE_LASER_DEVICE_FACTORY_H_
-# define SMODE_LASER_DEVICE_FACTORY_H_
+#ifndef SMODE_NANNOU_LASER_DEVICE_FACTORY_H_
+# define SMODE_NANNOU_LASER_DEVICE_FACTORY_H_
 
 #include "LaserLibrary.h"
-#include "LaserDeviceIdentifier.h"
-#include "LaserDevice.h"
+#include "NannouLaserDeviceIdentifier.h"
+#include "NannouLaserDevice.h"
 
 namespace smode
 {
@@ -24,10 +24,10 @@ String macAddressToString(uint8_t mac_address[6])
   return s;
 }
 
-class LaserDeviceFactory : public DeviceFactory
+class NannouLaserDeviceFactory : public DeviceFactory
 {
 public:
-  LaserDeviceFactory() {}
+  NannouLaserDeviceFactory() {}
 
   String getName() const override
   {
@@ -84,10 +84,10 @@ public:
       detected_dacs.assign(dacs, dacs + dac_count);
     }
 
-    // Convert the detected DACs into `LaserDeviceIdentifier`s that SMODE can work with.
+    // Convert the detected DACs into `NannouLaserDeviceIdentifier`s that SMODE can work with.
     for (auto dac : detected_dacs) {
       String mac_string = macAddressToString(dac.kind.ether_dream.broadcast.mac_address);
-      res.push_back(new LaserDeviceIdentifier(getName(), mac_string));
+      res.push_back(new NannouLaserDeviceIdentifier(getName(), mac_string));
     }
     return true;
   }
@@ -98,15 +98,14 @@ public:
       String mac_string = macAddressToString(dac.kind.ether_dream.broadcast.mac_address);
 
       if (mac_string == identifier.getFriendlyName()) {
-          LaserDevice* device = new LaserDevice(identifier, dac);
-          device->laser_api = &api;
+          NannouLaserDevice* device = new NannouLaserDevice(identifier, &api, dac);
           return device;
       }
     }
     return nullptr;
   }
 
-  OIL_OBJECT(LaserDeviceFactory);
+  OIL_OBJECT(NannouLaserDeviceFactory);
 
 private:
   mutable laser::Api api;
@@ -116,4 +115,4 @@ private:
 };
 }; /* namespace smode */
 
-#endif // !SMODE_LASER_DEVICE_FACTORY_H_
+#endif // !SMODE_NANNOU_LASER_DEVICE_FACTORY_H_

--- a/plugin/NannouLaserDeviceIdentifier.h
+++ b/plugin/NannouLaserDeviceIdentifier.h
@@ -1,27 +1,25 @@
 /* -------------------------------------- . ---------------------------------- .
-| Filename : LaserDeviceIdentifier.h      |                                    |
+| Filename : NannouLaserDeviceIdentifier.h|                                    |
 | Author   : MindBuffer                   |                                    |
 | Started  : 05/04/2020 07:16             |                                    |
 ` --------------------------------------- . --------------------------------- */
 
-#ifndef SMODE_LASER_DEVICE_IDENTIFIER_H_
-# define SMODE_LASER_DEVICE_IDENTIFIER_H_
+#ifndef SMODE_NANNOU_LASER_DEVICE_IDENTIFIER_H_
+# define SMODE_NANNOU_LASER_DEVICE_IDENTIFIER_H_
 
 #include "LaserLibrary.h"
 
 namespace smode
 {
-class LaserDeviceIdentifier : public StringDeviceIdentifier
+class NannouLaserDeviceIdentifier : public StringDeviceIdentifier
 {
 public:
-LaserDeviceIdentifier(const String& factory, const String& value)
+NannouLaserDeviceIdentifier(const String& factory, const String& value)
   : StringDeviceIdentifier(factory, value) {}
-LaserDeviceIdentifier() {}
+NannouLaserDeviceIdentifier() {}
 
-OIL_OBJECT(LaserDeviceIdentifier);
-
+OIL_OBJECT(NannouLaserDeviceIdentifier);
 };
-
 }; /* namespace smode */
 
-#endif // !SMODE_LASER_DEVICE_IDENTIFIER_H_
+#endif // !SMODE_NANNOU_LASER_DEVICE_IDENTIFIER_H_


### PR DESCRIPTION
This PR abstracts the `LaserDevice` into its own abstract class
along with the LASER `Point` type and a single virtual method called
`addLineSequence` (previously `concatFramePoints`). See the method
documentation comment for details on requirements for implementation.

A new `NannouLaserDevice` class has been added that inherits from
`LaserDevice`. The `LaserDeviceFactory` and `LaserDeviceIdentifier`
classes have been renamed to `NannouLaserDeviceFactory` and
`NannouLaserDeviceIdentifier` respectively.

The `Renderer` types remain generic over all classes inheriting from
`LaserDevice`.

This commit also removes some magic variables in favour of documented
static const fields.