### PR TITLE
Add necessary bindings generation for optimisation lib

### DIFF
--- a/smode_laser/Cargo.toml
+++ b/smode_laser/Cargo.toml
@@ -16,4 +16,4 @@ name = "smode_laser"
 crate-type = ["rlib", "staticlib", "cdylib"]
 
 [dependencies]
-nannou_laser = { version = "0.14", features = ["ffi"] }
+nannou_laser = { version = "0.14.3", features = ["ffi"] }

--- a/smode_laser/cbindgen.toml
+++ b/smode_laser/cbindgen.toml
@@ -2,5 +2,5 @@ language = "C++"
 namespaces = ["laser"]
 [parse]
 parse_deps = true
-include = ["nannou_laser", "ether-dream"]
-extra_bindings = ["nannou_laser", "ether-dream"]
+include = ["nannou_laser", "ether-dream", "lasy"]
+extra_bindings = ["nannou_laser", "ether-dream", "lasy"]


### PR DESCRIPTION
Recently the optimisation passes applied in `nannou_laser` were
refactored into a separate library. This patch ensures bindings are
properly generated for a couple of the types that have been moved.